### PR TITLE
Created special function for kicking inactive player

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -77,7 +77,7 @@ files["archtec_matterbridge/rx.lua"] = {
 }
 
 files["archtec/scripts/common.lua"] = {
-	globals = {"core.kick_player", "core.disconnect_player", "minetest.registered_chatcommands.?.mod_origin"},
+	globals = {"core.kick_player", "core.kick_inactive_player", "core.disconnect_player", "minetest.registered_chatcommands.?.mod_origin"},
 }
 
 files["archtec/scripts/overrides.lua"] = {

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -77,7 +77,7 @@ files["archtec_matterbridge/rx.lua"] = {
 }
 
 files["archtec/scripts/common.lua"] = {
-	globals = {"core.kick_player", "core.kick_inactive_player", "core.disconnect_player", "minetest.registered_chatcommands.?.mod_origin"},
+	globals = {"core.kick_player", "core.disconnect_player", "minetest.registered_chatcommands.?.mod_origin"},
 }
 
 files["archtec/scripts/overrides.lua"] = {

--- a/archtec/scripts/common.lua
+++ b/archtec/scripts/common.lua
@@ -43,11 +43,9 @@ function core.kick_player(player_name, reason)
 end
 
 function archtec.kick_inactive_player(player_name)
-	if archtec.is_online(player_name) then
-		minetest.chat_send_all(minetest.colorize("#FF0000", player_name .. " got kicked due to inactivity."))
-		archtec_matterbridge.send(":zzz: " .. player_name .. " got kicked due to inactivity.")
-		archtec.silent_leave[player_name] = true
-	end
+	minetest.chat_send_all(minetest.colorize("#FF0000", player_name .. " got kicked due to inactivity."))
+	archtec_matterbridge.send(":zzz: " .. player_name .. " got kicked due to inactivity.")
+	archtec.silent_leave[player_name] = true
 	return core.disconnect_player(player_name, "Too long inactive")
 end
 

--- a/archtec/scripts/common.lua
+++ b/archtec/scripts/common.lua
@@ -42,7 +42,7 @@ function core.kick_player(player_name, reason)
 	return core.disconnect_player(player_name, reason)
 end
 
-function core.kick_inactive_player(player_name)
+function archtec.kick_inactive_player(player_name)
 	if archtec.is_online(player_name) then
 		minetest.chat_send_all(minetest.colorize("#FF0000", player_name .. " got kicked due to inactivity."))
 		archtec_matterbridge.send(":zzz: " .. player_name .. " got kicked due to inactivity.")

--- a/archtec/scripts/common.lua
+++ b/archtec/scripts/common.lua
@@ -27,6 +27,7 @@ function archtec.revoke_priv(name, priv)
 end
 
 archtec.silent_leave = {}
+
 function core.kick_player(player_name, reason)
 	if type(reason) == "string" then
 		reason = "Kicked: " .. reason
@@ -39,6 +40,15 @@ function core.kick_player(player_name, reason)
 		archtec.silent_leave[player_name] = true
 	end
 	return core.disconnect_player(player_name, reason)
+end
+
+function core.kick_inactive_player(player_name)
+	if archtec.is_online(player_name) then
+		minetest.chat_send_all(minetest.colorize("#FF0000", player_name .. " got kicked due to inactivity."))
+		archtec_matterbridge.send(":zzz: " .. player_name .. " got kicked due to inactivity.")
+		archtec.silent_leave[player_name] = true
+	end
+	return core.disconnect_player(player_name, "Too long inactive")
 end
 
 function archtec.split_itemname(itemname)

--- a/archtec/scripts/idlekick.lua
+++ b/archtec/scripts/idlekick.lua
@@ -76,7 +76,7 @@ minetest.register_globalstep(function(dtime)
 		end
 
 		if cache[name].last_active < time - timeout then
-			minetest.kick_inactive_player(name)
+			archtec.kick_inactive_player(name)
 		end
 
 		if cache[name].last_active < time - 300 then

--- a/archtec/scripts/idlekick.lua
+++ b/archtec/scripts/idlekick.lua
@@ -76,7 +76,7 @@ minetest.register_globalstep(function(dtime)
 		end
 
 		if cache[name].last_active < time - timeout then
-			minetest.kick_player(name, "Too long inactive")
+			minetest.kick_inactive_player(name)
 		end
 
 		if cache[name].last_active < time - 300 then


### PR DESCRIPTION
Solves Archtec-io/bugtracker#171.

Now it should say in bridged chats:

```
💤 <PLAYER_NAME> got kicked due to inactivity.
```

And project the same message to Minetest, of course.

Not sure if the color must be changed, since it's a toned down message, but it also can easily slip one's mind that their friend just got kicked, simply because the color is not eye-soring anymore. So, I didn't change that, at least.